### PR TITLE
added run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To replace the `/boot/occidentalis.txt` (as we want this feature for more boards
 * ☐ Set static IP (see hypriot/flash#25)
 * ☑ Pull some docker images
 * ☐ Install a list of DEB packages
-* ☐ Run a custom script from /boot
+* ☑ Run a custom script from /boot
 * ...
 
 ## The /boot/device-init.yaml
@@ -46,6 +46,15 @@ docker:
     - "/path/to/image-name.tar.gz"
     - "/path/to/another-image-name.tar"
 ```
+
+### Run a Command
+device-init can execute a list of commands on boot. e.g.:
+```yaml
+runcmd:
+  - "apt-get install package-name"
+  - "curl https://raw.githubusercontent.com/.../myscript.sh | sh"
+```
+Make sure that the command lines do not produce YAML syntax errors. You can check [here](http://www.yamllint.com/)  
 
 ### Hypriot Cluster-Lab
 device-init can start the Hypriot Cluster-Lab on start up by setting the 'run_on_boot' option to 'true'.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ func setAllCommands() {
 		setWifi()
 		dockerPreloadImages()
 		manageClusterLab()
+		runCommands()
 	}
 }
 

--- a/cmd/runcommand.go
+++ b/cmd/runcommand.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os/exec"
+)
+
+// runCmd represents the run command to execute shell commands
+var runCmd = &cobra.Command{
+	Use:   "runcommand",
+	Short: "Run shell commands",
+	Long:  `Run shell commands that are defined in device-init.yaml.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runCommands()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(runCmd)
+}
+
+func runCommands() {
+	commandList := config.GetStringSlice("runcmd")
+	for _, command := range commandList {
+		err := exec.Command("sh", "-c", command).Run()
+		if err != nil {
+			fmt.Printf("Unable to run command %v. Reason: %v\n", command, err)
+		}
+	}
+}

--- a/specs/device-init_spec.rb
+++ b/specs/device-init_spec.rb
@@ -308,5 +308,35 @@ ff02::2 ip6-allrouters
       expect(cat_cmd.exit_status).to be(1)
     end
   end
+
+  context "run command" do
+      let(:runcommand)  { File.read(File.join(File.dirname(__FILE__), 'testdata', 'runcommand.yaml')) }
+       before(:each) do
+               echo_config_cmd = command(%Q(rm -f /boot/device-init.yaml))
+               expect(echo_config_cmd.exit_status).to be(0)
+       end
+
+        it "executes commands" do
+            echo_config_cmd = command(%Q(echo -n '#{runcommand}' > /boot/device-init.yaml))
+            expect(echo_config_cmd.exit_status).to be(0)
+
+            device_init_cmd = command('device-init --config')
+            expect(device_init_cmd.exit_status).to be(0)
+
+            test_file = file('/tmp/test-without-quotes.txt')
+            expect(test_file.exists?).to be(true)
+
+            test_file = file('/tmp/test-with-quotes.txt')
+            expect(test_file.exists?).to be(true)
+        end
+
+        it "doesn't choke on a config file without runcmd key" do
+                echo_config_cmd = command(%Q(echo -n '' > /boot/device-init.yaml))
+                expect(echo_config_cmd.exit_status).to be(0)
+
+                device_init_cmd = command('device-init --config')
+                expect(device_init_cmd.exit_status).to be(0)
+              end
+  end
 end
 

--- a/specs/testdata/runcommand.yaml
+++ b/specs/testdata/runcommand.yaml
@@ -1,0 +1,5 @@
+runcmd:
+   # Execute a line. It does not require quotes, because it is valid yaml
+ - ls / | grep home > /tmp/test-without-quotes.txt
+   # Execute a line that requires quotes, because the colon is followed by space and would cause invalid yaml otherwise
+ - "echo hello: > /tmp/test-with-quotes.txt"


### PR DESCRIPTION
Added option to execute custom shell commands (e.g.  scripts) during device init.

Syntax is similar to cloud init.

@kenan435, @zreigz 

