### PR TITLE
Add ethernet interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ wifi:
       password: "secret_password"
 ```
 
+### Ethernet Settings
+
+```yaml
+ethernet:
+  interfaces:
+    eth0:
+      address: 192.168.1.2
+      network: 192.168.1.0
+      gateway: 192.168.1.1
+      netmask: 255.255.255.255
+      broadcast: 192.168.1.255
+```
+
 ### Docker Preload Images Settings
 device-init can preload local image files into the Docker engine on boot.
 Those images have to be exported via 'docker save image-name > image-name.tar'.

--- a/cmd/ethernet.go
+++ b/cmd/ethernet.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var cmdEthernetInterfaceName string
+var cmdAddress string
+var cmdNetmask string
+var cmdNetwork string
+var cmdGateway string
+var cmdBroadcast string
+
+type InterfaceInfo struct {
+	Address, Netmask, Network, Gateway, Broadcast string
+}
+
+type EthernetConfig struct {
+	Interfaces map[string]InterfaceInfo
+}
+
+var myEthernetConfig EthernetConfig
+
+// var networkInterfacesPath = "/etc/network/interfaces.d" // Already defined in wifi.go
+
+// ethernetCmd represents the ethernet command
+var ethernetCmd = &cobra.Command{
+	Use:   "ethernet",
+	Short: "set Ethernet settings",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		cmd.Help()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(ethernetCmd)
+
+	ethernetCmd.PersistentFlags().StringVarP(&cmdInterfaceName, "interface_name", "i", "", "Name of your network interface e.g. eth0")
+}
+
+func readEthernetConfig() {
+	err := config.UnmarshalKey("ethernet", &myEthernetConfig)
+	if err != nil {
+		fmt.Println("Could not unmarshal Ethernet configuration")
+	}
+}

--- a/cmd/ethernet_set.go
+++ b/cmd/ethernet_set.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+// setCmd represents the set command
+var setEthernetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set Ethernet settings",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		setEthernet()
+	},
+}
+
+func setEthernet() {
+	var err error
+
+	readEthernetConfig()
+
+	const interfaceTemplate = `allow-hotplug {{.Name}}
+
+auto {{.Name}}
+iface {{.Name}} inet static
+  address {{.Address}}
+  netmask {{.Netmask}}
+  network {{.Network}}
+  gateway {{.Gateway}}
+  broadcast {{.Broadcast}}
+`
+
+	// if we have command line parameters only add those to our ethernet configuration
+	if cmdAddress != "" &&
+		cmdNetmask != "" &&
+		cmdNetwork != "" &&
+		cmdGateway != "" &&
+		cmdBroadcast != "" {
+		for key := range myEthernetConfig.Interfaces {
+			delete(myEthernetConfig.Interfaces, key)
+		}
+		myEthernetConfig.Interfaces = make(map[string]InterfaceInfo)
+		myEthernetConfig.Interfaces[cmdInterfaceName] = InterfaceInfo{
+			Address:   cmdAddress,
+			Netmask:   cmdNetmask,
+			Network:   cmdNetwork,
+			Gateway:   cmdGateway,
+			Broadcast: cmdBroadcast,
+		}
+	}
+
+	for interfaceName, interfaceInfo := range myEthernetConfig.Interfaces {
+
+		type templateVariables struct {
+			Name, Address, Netmask, Network, Gateway, Broadcast string
+		}
+
+		variables := templateVariables{
+			Name:      interfaceName,
+			Address:   interfaceInfo.Address,
+			Netmask:   interfaceInfo.Netmask,
+			Network:   interfaceInfo.Network,
+			Gateway:   interfaceInfo.Gateway,
+			Broadcast: interfaceInfo.Broadcast,
+		}
+
+		err = os.MkdirAll("/etc/network/interfaces.d/", 0755)
+		if err != nil {
+			fmt.Println("Could not create path: ", "/etc/network/interfaces.d/")
+		}
+
+		fmt.Println("TEST")
+		configFilePath := path.Join("/etc/network/interfaces.d/", interfaceName)
+		if _, err := os.Stat(configFilePath); err == nil {
+			filepath, filename := path.Dir(configFilePath), path.Base(configFilePath)
+			backupFile := "." + filename + ".backup"
+			backupPath := path.Join(filepath, backupFile)
+			err = os.Rename(configFilePath, backupPath)
+			if err != nil {
+				fmt.Println("Could not backup file ", backupPath, ": ", err)
+			}
+		}
+
+		f, err := os.Create(configFilePath)
+		defer f.Close()
+		if err != nil {
+			fmt.Println("Could not create file: "+configFilePath+": ", err)
+		}
+
+		t := template.Must(template.New("config").Parse(interfaceTemplate))
+
+		err = t.Execute(f, variables)
+		if err != nil {
+			fmt.Println("Error writing configuration:", err)
+		}
+
+		if interfaceExistsAndIsDown(interfaceName) {
+			output, err := exec.Command("/sbin/ifup", interfaceName).CombinedOutput()
+			if err != nil {
+				message := fmt.Sprintf("Could not bring up interface %s: %s", interfaceName, err)
+				fmt.Println(message)
+			}
+			fmt.Println(string(output)[:])
+		}
+
+		// try to bring the interface up once more but bring it down before
+		if interfaceExistsAndIsDown(interfaceName) {
+			output, err := exec.Command("/sbin/ifdown", interfaceName).CombinedOutput()
+			if err != nil {
+				message := fmt.Sprintf("Could not bring the interface down %s: %s ", interfaceName, err)
+				fmt.Println(message)
+			}
+			fmt.Println(string(output)[:])
+			output, err = exec.Command("/sbin/ifup", interfaceName).CombinedOutput()
+			if err != nil {
+				message := fmt.Sprintf("Could still not bring up interface %s: %s", interfaceName, err)
+				fmt.Println(message)
+			}
+		}
+	}
+}
+
+func init() {
+	ethernetCmd.AddCommand(setEthernetCmd)
+	setEthernetCmd.Flags().StringVarP(&cmdAddress, "address", "a", "", "The desired address")
+	setEthernetCmd.Flags().StringVarP(&cmdNetmask, "netmask", "m", "", "The netmask of the network")
+	setEthernetCmd.Flags().StringVarP(&cmdNetwork, "network", "n", "", "The network direction")
+	setEthernetCmd.Flags().StringVarP(&cmdGateway, "gateway", "g", "", "The default gateway")
+	setEthernetCmd.Flags().StringVarP(&cmdBroadcast, "broadcast", "b", "", "The broadcast address")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func setAllCommands() {
 	if err := config.ReadInConfig(); err == nil {
 		setHostname()
 		setWifi()
+		setEthernet()
 		dockerPreloadImages()
 		manageClusterLab()
 		runCommands()

--- a/specs/testdata/ethernet_interface.yaml
+++ b/specs/testdata/ethernet_interface.yaml
@@ -1,0 +1,9 @@
+ethernet:
+  interfaces:
+    eth0:
+      eth0:
+        address: 192.168.1.2
+        netmask: 255.255.255.0
+        network: 192.168.1.0
+        gateway: 192.168.1.1
+        broadcast: 192.168.1.255

--- a/specs/testdata/no_ethernet_interface.yaml
+++ b/specs/testdata/no_ethernet_interface.yaml
@@ -1,0 +1,1 @@
+hostname: blue-diamond

--- a/specs/testdata/one_ethernet_interface.yaml
+++ b/specs/testdata/one_ethernet_interface.yaml
@@ -1,0 +1,8 @@
+ethernet:
+  interfaces:
+    eth0:
+      address: 192.168.1.2
+      netmask: 255.255.255.0
+      network: 192.168.1.0
+      gateway: 192.168.1.1
+      broadcast: 192.168.1.255

--- a/specs/testdata/two_ethernet_interfaces.yaml
+++ b/specs/testdata/two_ethernet_interfaces.yaml
@@ -1,0 +1,14 @@
+ethernet:
+  interfaces:
+    eth0:
+      address: 192.168.1.2
+      netmask: 255.255.255.0
+      network: 192.168.1.0
+      gateway: 192.168.1.1
+      broadcast: 192.168.1.255
+    eth1:
+      address: 10.1.1.2
+      netmask: 255.255.0.0
+      network: 10.1.0.0
+      gateway: 10.1.0.1
+      broadcast: 10.1.255.255


### PR DESCRIPTION
Title.

Currently it only supports static ip (maybe I could add DHCP?)
Also, you need to put all the information of the interface, when actually only `address`, `gateway` and one of `network`, `netmask` or `broadcast` is necessary.

I'm not sure about copyright, so if I have to add any kind of notice, don't hesitate to ask.

Also, I use some functions/variables that are in `wifi_set.go`. I'm not sure about Go style, but I guess I should refactorize them to an external common file?